### PR TITLE
no_special_cards working

### DIFF
--- a/games/wizardsapprentice/ressources/experiment_settings/full_no_special_cards.json
+++ b/games/wizardsapprentice/ressources/experiment_settings/full_no_special_cards.json
@@ -8,7 +8,7 @@
     "DIFFICULTY": "standard",
     "COLORS": ["G", "B", "R", "Y"],
     "CARDS_PER_COLOR": 13,
-    "SPECIAL_CARDS": ["", ""],
+    "SPECIAL_CARDS": [],
     "SPECIAL_CARDS_NUM": 4,
     "LIBERAL_MODE": true,
     "ATTEMPTS": 5,


### PR DESCRIPTION
Adjust the instancegenerator and experiment settings such that a deck without special cards can be generated